### PR TITLE
fix: YOLO model path, Docker CPU optimization, remove dead import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt .
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
+# Install PyTorch CPU-only first (smaller image: ~4.6 GB vs ~11 GB).
+# GPU users: docker compose build --build-arg TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124
+ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
 RUN pip install --upgrade pip
+RUN pip install --no-cache-dir --index-url ${TORCH_INDEX_URL} torch==2.11.0 torchvision==0.26.0
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Final stage
@@ -37,6 +41,9 @@ COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
 
+# Point YOLO to pre-downloaded model (survives volume mount)
+ENV YOLO_MODEL_PATH=/tmp/Ultralytics/yolov8n.pt
+
 # Always upgrade yt-dlp to latest (YouTube bot-detection changes frequently)
 RUN pip install --upgrade --no-cache-dir yt-dlp
 
@@ -55,7 +62,7 @@ RUN chown -R appuser:appuser /app /tmp/Ultralytics
 USER appuser
 
 # Pre-download YOLO model on build (now running as appuser)
-RUN python -c "from ultralytics import YOLO; YOLO('yolov8n.pt')"
+RUN python -c "from ultralytics import YOLO; YOLO('/tmp/Ultralytics/yolov8n.pt')"
 
 # Expose FastAPI port
 EXPOSE 8000

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import time
 import cv2
-import scenedetect
 import subprocess
 import argparse
 import re
@@ -68,7 +67,8 @@ OUTPUT — RETURN ONLY VALID JSON (no markdown, no comments). Order clips by pre
 """
 
 # Load the YOLO model once (Keep for backup or scene analysis if needed)
-model = YOLO('yolov8n.pt')
+YOLO_MODEL_PATH = os.environ.get("YOLO_MODEL_PATH", "yolov8n.pt")
+model = YOLO(YOLO_MODEL_PATH)
 
 # --- MediaPipe Setup ---
 # Use standard Face Detection (BlazeFace) for speed


### PR DESCRIPTION
## Context

Deploying on a VPS (Docker) hits 3 bugs that prevent the app from running.

## Changes

### 1. Make YOLO model path configurable (main.py + Dockerfile)
- `YOLO("yolov8n.pt")` tries to download to CWD, but `/app` is volume-mounted in docker-compose, so the app user has no write permission → `PermissionError`
- Add `YOLO_MODEL_PATH` env var (default: `yolov8n.pt` for bare-metal auto-download)
- Docker sets `/tmp/Ultralytics/yolov8n.pt` (pre-downloaded during build, survives volume mount)
- Bare-metal users get auto-download to CWD — no breakage

### 2. CPU-only PyTorch by default in Docker (Dockerfile)
- Split pip install: `torch` via `--index-url` (explicit), rest via `requirements.txt`
- `TORCH_INDEX_URL` build arg (default: `https://download.pytorch.org/whl/cpu`)
- GPU users: `docker compose build --build-arg TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124`
- Image: **11.3 GB → 4.6 GB**

This follows the same pattern as [PyTorch own Dockerfile](https://github.com/pytorch/pytorch/blob/main/Dockerfile) which uses `ARG CUDA_PATH=cu121`.

### 3. Remove unused `import scenedetect` (main.py)
Dead code after the `open_video()` refactor — no `scenedetect.` references remain.

## Testing
- [x] `docker compose build` succeeds (4.6 GB image)
- [x] Backend starts and serves API on :8000
- [x] YOLO model loads from env-configured path
- [x] `requirements.txt` unchanged — bare-metal `pip install` still works