### PR TITLE
fix(remotion): honor per-render duration/fps/dimensions via calculateMetadata

### DIFF
--- a/remotion/src/Root.tsx
+++ b/remotion/src/Root.tsx
@@ -84,6 +84,12 @@ export const RemotionRoot: React.FC = () => {
         width={DEFAULT_PROPS.width}
         height={DEFAULT_PROPS.height}
         defaultProps={DEFAULT_PROPS}
+        calculateMetadata={({ props }) => ({
+          durationInFrames: props.durationInFrames,
+          fps: props.fps,
+          width: props.width,
+          height: props.height,
+        })}
       />
     </>
   );


### PR DESCRIPTION
## Problem

The `ShortVideo` `<Composition>` in `remotion/src/Root.tsx` hardcodes `durationInFrames`/`fps`/`width`/`height` from `DEFAULT_PROPS`, and there is no `calculateMetadata` callback. Remotion's `selectComposition()` (called from `render-service/src/render-worker.ts` before `renderMedia()`) therefore always resolves the composition's static metadata instead of deriving it from the `inputProps` actually passed in for a given render job.

In practice, every render produced via `render-service` comes out at a fixed 900 frames / 30fps / 1080x1920, regardless of what `durationInFrames`/`fps`/`width`/`height` the caller sent in `props`.

## Repro

Submitted a `POST /render` with a 10s source video and `durationInFrames: 300, fps: 30, width: 1080, height: 1920`. Output file was 30.0s (900 frames) instead of 10s — the source video freezes on its last frame for the remaining ~20s while the composition timeline keeps running.

```
ffprobe output: duration=30.000000, nb_frames=900 (expected: ~10s, 300 frames)
```

## Fix

Add a `calculateMetadata` callback to the `<Composition>` that derives `durationInFrames`/`fps`/`width`/`height` directly from the render's `props`, so `selectComposition`/`renderMedia` use the real requested values instead of the static defaults.

Verified locally: same repro after the fix produces a 10.048s (300-frame) output, matching the requested `durationInFrames`.

## Scope

This is an isolated one-file fix, no unrelated changes bundled in.