### PR TITLE
Clip editor: source monitor, three-point editing, and a timeline that works while edited

### DIFF
--- a/app.py
+++ b/app.py
@@ -2224,9 +2224,10 @@ async def get_clip_transcript(job_id: str, clip_index: int, request: Request):
 
 # --- Clip editor: EDL + re-render ---
 
-# How much transcript to send around the clip's segments — enough for the
-# editor's word-level trimming without shipping a whole podcast's words.
-EDL_WORD_CONTEXT_SECONDS = 45.0
+# The editor ships the WHOLE source transcript, not a window around the clip:
+# the point of the source track is extending a cut into material the clip never
+# covered, and you cannot pick a new in-point from words you were not sent.
+# Cost is about 7 KB of JSON per minute of speech, fetched once per editor open.
 
 
 def _source_duration_seconds(path):
@@ -2295,11 +2296,9 @@ async def get_clip_edl(job_id: str, clip_index: int, request: Request):
             candidates.append(words[-1]['e'])
         source_duration = round(max(candidates), 3)
 
-    lo = min(s['start'] for s in segments) - EDL_WORD_CONTEXT_SECONDS
-    hi = max(s['end'] for s in segments) + EDL_WORD_CONTEXT_SECONDS
     words_out = [
         {"w": w["w"], "s": round(w["s"], 3), "e": round(w["e"], 3)}
-        for w in words if w["e"] >= lo and w["s"] <= hi
+        for w in words
     ]
 
     current_file = (clip.get('video_url') or '').split('/')[-1]

--- a/dashboard/src/components/ClipEditor.jsx
+++ b/dashboard/src/components/ClipEditor.jsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect, useReducer, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useReducer, useRef, useCallback, useMemo, useDeferredValue } from 'react';
 import {
     X, Loader2, Plus, Trash2, ChevronUp, ChevronDown, Scissors,
-    AlertCircle, Undo2, Redo2, Film,
+    AlertCircle, Undo2, Redo2, ChevronsRight, ChevronsLeft,
+    PanelLeft, PanelLeftClose, Film,
 } from 'lucide-react';
 import { getApiUrl } from '../config';
 import { apiFetch, apiJson, QuotaError } from '../lib/api';
@@ -12,7 +13,16 @@ import { apiFetch, apiJson, QuotaError } from '../lib/api';
 
 const MIN_SEGMENT_SECONDS = 0.5;
 const SNAP_WINDOW_SECONDS = 0.35;
-const WORD_CONTEXT_SECONDS = 15;
+
+// Hiding the source is a working preference, not a per-clip one, so it sticks.
+const HIDE_SOURCE_KEY = 'openshorts_editor_hide_source';
+
+// Words per memoised transcript slice. See TranscriptChunk for why this exists.
+const CHUNK_WORDS = 50;
+
+// Segment edges round-trip through 3 decimals, so coverage arithmetic needs a
+// hair of tolerance before it calls a millisecond sliver "not rendered".
+const COVERAGE_EPSILON = 0.02;
 
 const SEGMENT_COLORS = [
     'oklch(76% .17 50)',   // brass
@@ -104,7 +114,16 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
     const [confirmClose, setConfirmClose] = useState(false);
     const [selectedWord, setSelectedWord] = useState(null);
     const [playhead, setPlayhead] = useState(0);
-    const [showSource, setShowSource] = useState(false);
+    const [showSource, setShowSource] = useState(() => {
+        try { return localStorage.getItem(HIDE_SOURCE_KEY) !== '1'; } catch { return true; }
+    });
+    // Where the source monitor's playhead is, for the transcript to follow.
+    const [sourceTime, setSourceTime] = useState(0);
+    // Three-point editing, like a Premiere source monitor: mark IN and OUT on
+    // the source, then send that range to the clip. Kept as two independent
+    // numbers rather than a range so either end can be re-marked on its own.
+    const [markIn, setMarkIn] = useState(null);
+    const [markOut, setMarkOut] = useState(null);
 
     const videoRef = useRef(null);
     const sourceRef = useRef(null);
@@ -112,6 +131,50 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
     const sourceTrackRef = useRef(null);
     const dragRef = useRef(null);
     const [ghost, setGhost] = useState(null); // in-progress new segment on the source track
+    const transcriptRef = useRef(null);
+
+    useEffect(() => {
+        try { localStorage.setItem(HIDE_SOURCE_KEY, showSource ? '0' : '1'); } catch { /* private mode */ }
+    }, [showSource]);
+
+    // ---- scrubbing the source monitor ---------------------------------------
+    // Dragging on the source track drives this <video>, so the cut is chosen
+    // against the picture instead of against numbers. rAF-throttled: a drag
+    // fires dozens of pointermoves a second and assigning currentTime on each
+    // one makes the element stutter. `pending` also survives a seek issued
+    // before the metadata is in, which onLoadedMetadata then applies.
+    const seekRef = useRef({ pending: null, raf: 0, timer: 0 });
+
+    const applySeek = useCallback(() => {
+        if (seekRef.current.raf) cancelAnimationFrame(seekRef.current.raf);
+        if (seekRef.current.timer) clearTimeout(seekRef.current.timer);
+        seekRef.current.raf = 0;
+        seekRef.current.timer = 0;
+        const v = sourceRef.current;
+        const t = seekRef.current.pending;
+        if (!v || t === null) return;
+        if (v.readyState === 0) return;          // retried from onLoadedMetadata
+        if (!v.paused) v.pause();                // a moving picture cannot be aimed
+        try { v.currentTime = Math.max(0, t); } catch { /* seek refused, keep pending */ }
+        seekRef.current.pending = null;
+    }, []);
+
+    const seekSource = useCallback((t) => {
+        if (!Number.isFinite(t)) return;
+        seekRef.current.pending = t;
+        if (seekRef.current.raf || seekRef.current.timer) return;   // one per frame
+        seekRef.current.raf = requestAnimationFrame(applySeek);
+        // The timer is the recovery path, not a second throttle: a hidden or
+        // occluded tab never runs a rAF callback, so a latch waiting only on
+        // rAF would deadlock the scrub for the rest of the session. Whichever
+        // fires first cancels the other.
+        seekRef.current.timer = setTimeout(applySeek, 120);
+    }, [applySeek]);
+
+    useEffect(() => () => {
+        if (seekRef.current.raf) cancelAnimationFrame(seekRef.current.raf);
+        if (seekRef.current.timer) clearTimeout(seekRef.current.timer);
+    }, []);
 
     // ---- load the EDL -------------------------------------------------------
     useEffect(() => {
@@ -140,6 +203,11 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
     const canonical = edl?.canonical_range || { start: 0, end: 0 };
     const limits = edl?.limits || { max_segments: 12, min_segment_seconds: MIN_SEGMENT_SECONDS, max_total_seconds: 180 };
     const minSeg = limits.min_segment_seconds || MIN_SEGMENT_SECONDS;
+
+    // The source panel is on screen only when there IS a source and the user
+    // has not put it away. An expired source forces the same two-column layout
+    // the hide button asks for, so both cases share one code path.
+    const sourceOpen = sourceAvailable && showSource;
 
     const total = totalOf(segments);
     const dirty = useMemo(() => {
@@ -223,17 +291,16 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
         const seg = segments[index];
         if (seg.end - seg.start < minSeg * 2) return;
         let at = seg.start + (seg.end - seg.start) / 2;
-        // Prefer the playhead when it currently maps inside this segment.
-        if (!dirty && renderedSegments) {
-            let offset = 0;
-            for (let i = 0; i < renderedSegments.length; i += 1) {
-                const r = renderedSegments[i];
-                const len = r.end - r.start;
-                if (i === index && playhead > offset + minSeg && playhead < offset + len - minSeg) {
-                    at = r.start + (playhead - offset);
-                }
-                offset += len;
+        // Cut where the playhead is, when it sits inside this segment. It lives
+        // on the current assembly now, so this no longer needs the rendered
+        // recipe to still match.
+        let offset = 0;
+        for (let i = 0; i < segments.length; i += 1) {
+            const len = segments[i].end - segments[i].start;
+            if (i === index && playhead > offset + minSeg && playhead < offset + len - minSeg) {
+                at = segments[i].start + (playhead - offset);
             }
+            offset += len;
         }
         at = snapEdge(at, 'end');
         if (at - seg.start < minSeg || seg.end - at < minSeg) at = seg.start + (seg.end - seg.start) / 2;
@@ -243,14 +310,26 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
         dispatch({ type: 'commit', segments: next, select: index });
     };
 
-    // ---- drag: trim handles on the clip track -------------------------------
+    // ---- drag: trim/move handles on both tracks -----------------------------
+    // ``edge`` is 'start' | 'end' (trim one boundary) or 'move' (slide the whole
+    // segment along the source, keeping its duration).
     const onDragMove = useCallback((e) => {
         const d = dragRef.current;
-        if (!d) return;
+        if (!d || d.kind) return;   // a ghost or a scrub, not a trim
         const dt = (e.clientX - d.startX) / d.pxPerSec;
         const seg = { ...d.base[d.idx] };
-        if (d.edge === 'start') seg.start = Math.max(d.lo, Math.min(seg.start + dt, seg.end - d.minSeg));
-        else seg.end = Math.min(d.hi, Math.max(seg.end + dt, seg.start + d.minSeg));
+        if (d.edge === 'move') {
+            const len = seg.end - seg.start;
+            seg.start = Math.max(d.lo, Math.min(seg.start + dt, d.hi - len));
+            seg.end = seg.start + len;
+        } else if (d.edge === 'start') {
+            seg.start = Math.max(d.lo, Math.min(seg.start + dt, seg.end - d.minSeg));
+        } else {
+            seg.end = Math.min(d.hi, Math.max(seg.end + dt, seg.start + d.minSeg));
+        }
+        // Source-track drags scrub the monitor to the edge being moved, so
+        // the frame on screen IS the frame the cut lands on.
+        if (d.scrub) d.seek(d.edge === 'end' ? seg.end : seg.start);
         const next = d.base.map((s, i) => (i === d.idx ? seg : s));
         d.last = { seg, next };
         dispatch({ type: 'preview', segments: next });
@@ -261,27 +340,54 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
         dragRef.current = null;
         window.removeEventListener('pointermove', onDragMove);
         window.removeEventListener('pointerup', onDragUp);
+        window.removeEventListener('pointercancel', onDragUp);
         if (!d || !d.last) return;
         const { seg, next } = d.last;
         const snapped = { ...seg };
-        if (d.edge === 'start') snapped.start = Math.max(d.lo, Math.min(d.snap(seg.start, 'start'), seg.end - d.minSeg));
-        else snapped.end = Math.min(d.hi, Math.max(d.snap(seg.end, 'end'), seg.start + d.minSeg));
-        dispatch({ type: 'commit', segments: next.map((s, i) => (i === d.idx ? snapped : s)), select: d.idx });
+        if (d.edge === 'move') {
+            const len = seg.end - seg.start;
+            const start = Math.max(d.lo, Math.min(d.snap(seg.start, 'start'), d.hi - len));
+            snapped.start = start;
+            snapped.end = start + len;
+        } else if (d.edge === 'start') {
+            snapped.start = Math.max(d.lo, Math.min(d.snap(seg.start, 'start'), seg.end - d.minSeg));
+        } else {
+            snapped.end = Math.min(d.hi, Math.max(d.snap(seg.end, 'end'), seg.start + d.minSeg));
+        }
+        // Round like every other edit path: the number inputs in the rail show
+        // these values, and raw drag arithmetic yields 190.22000000000003.
+        const clean = { start: Math.round(snapped.start * 1000) / 1000, end: Math.round(snapped.end * 1000) / 1000 };
+        dispatch({ type: 'commit', segments: next.map((s, i) => (i === d.idx ? clean : s)), select: d.idx });
     }, [onDragMove]);
 
     const startTrimDrag = (e, idx, edge, trackEl, secondsOnTrack) => {
+        // Only the primary button drags — and preventDefault is what stops
+        // Chrome from turning the gesture into a text selection (and then into
+        // a native drag-and-drop, which swallows every later pointer event and
+        // shows the 🚫 cursor instead of dragging anything).
+        if (e.button !== undefined && e.button !== 0) return;
         e.preventDefault();
         e.stopPropagation();
         const rect = trackEl?.getBoundingClientRect();
         if (!rect || !secondsOnTrack) return;
+        try { e.currentTarget.setPointerCapture?.(e.pointerId); } catch { /* not captured, window listeners still fire */ }
+        // Only the source track maps 1:1 onto source time; the clip track's
+        // x-axis is the recut's own timeline, which the monitor knows nothing of.
+        const scrub = trackEl === sourceTrackRef.current;
+        if (scrub) {
+            const seg = segments[idx];
+            if (seg) seekSource(edge === 'end' ? seg.end : seg.start);
+        }
         dragRef.current = {
             idx, edge, startX: e.clientX, pxPerSec: rect.width / secondsOnTrack,
             base: segments.map((s) => ({ ...s })), last: null,
             lo: bounds.lo, hi: bounds.hi, minSeg, snap: snapEdge,
+            scrub, seek: seekSource,
         };
         dispatch({ type: 'select', index: idx });
         window.addEventListener('pointermove', onDragMove);
         window.addEventListener('pointerup', onDragUp);
+        window.addEventListener('pointercancel', onDragUp);
     };
 
     // ---- drag: paint a NEW segment on the source track ----------------------
@@ -289,6 +395,7 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
         const d = dragRef.current;
         if (!d || d.kind !== 'ghost') return;
         const t = Math.max(0, Math.min(d.duration, d.t0 + (e.clientX - d.startX) / d.pxPerSec));
+        d.seek(t);
         d.range = { start: Math.min(d.t0, t), end: Math.max(d.t0, t) };
         setGhost({ ...d.range });
     }, []);
@@ -298,29 +405,354 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
         dragRef.current = null;
         window.removeEventListener('pointermove', onGhostMove);
         window.removeEventListener('pointerup', onGhostUp);
+        window.removeEventListener('pointercancel', onGhostUp);
         setGhost(null);
         if (!d || !d.range) return;
         const seg = {
             start: Math.round(d.snap(d.range.start, 'start') * 1000) / 1000,
             end: Math.round(d.snap(d.range.end, 'end') * 1000) / 1000,
         };
-        if (seg.end - seg.start < d.minSeg || d.count >= d.maxSegments) return;
-        d.commit(seg);
+        if (seg.end - seg.start < d.minSeg) return;
+        // Marks, not a segment: dragging here proposes a range, and nothing
+        // enters the clip until it is sent. One concept instead of two, and
+        // the range stays adjustable before it is committed.
+        d.mark(seg.start, seg.end);
     }, [onGhostMove]);
 
     const startGhostDrag = (e) => {
-        if (!sourceAvailable || !sourceDuration || segments.length >= limits.max_segments) return;
+        if (e.button !== undefined && e.button !== 0) return;
+        if (!sourceAvailable || !sourceDuration) return;
         const rect = sourceTrackRef.current?.getBoundingClientRect();
         if (!rect) return;
+        // Same reason as startTrimDrag: without this Chrome selects the track's
+        // labels and the follow-up gesture becomes a native text drag.
+        e.preventDefault();
         const t0 = ((e.clientX - rect.left) / rect.width) * sourceDuration;
+        // Landing anywhere on the track parks the monitor there — that alone is
+        // how you find a cut point, so it happens even when the segment cap is
+        // reached and no new block can be painted.
+        seekSource(t0);
+        try { e.currentTarget.setPointerCapture?.(e.pointerId); } catch { /* window listeners still fire */ }
         dragRef.current = {
             kind: 'ghost', startX: e.clientX, pxPerSec: rect.width / sourceDuration,
             t0, duration: sourceDuration, range: null, snap: snapEdge, minSeg,
-            count: segments.length, maxSegments: limits.max_segments,
-            commit: (seg) => dispatch({ type: 'commit', segments: [...segments, seg], select: segments.length }),
+            seek: seekSource,
+            mark: (a, b) => { setMarkIn(a); setMarkOut(b); },
         };
         window.addEventListener('pointermove', onGhostMove);
         window.addEventListener('pointerup', onGhostUp);
+        window.addEventListener('pointercancel', onGhostUp);
+    };
+
+    // ---- what of this edit the rendered file can already show ---------------
+    // The rendered file IS renderedSegments cut and concatenated in order (see
+    // perform_recut), so any instant of source still inside one of those ranges
+    // exists in the file and can be played straight from it. That is why a cut
+    // that only REMOVES material stays previewable: every frame it keeps was
+    // already rendered. Only material the last render never saw is missing, and
+    // that is what turns red.
+    const coverage = useMemo(() => {
+        if (!segments.length) return [];
+        // A framing change invalidates the whole file even where the ranges
+        // still line up: the crop baked into those frames is not what will
+        // come out.
+        if (!renderedSegments || framing !== renderedFraming) {
+            return [{ start: 0, end: totalOf(segments), rendered: null }];
+        }
+        const spans = [];
+        let clipAcc = 0;
+        for (const seg of segments) {
+            const segLen = seg.end - seg.start;
+            // Where this segment overlaps the rendered ones, and at what offset
+            // into the file each overlap lands.
+            const pieces = [];
+            let renAcc = 0;
+            for (const r of renderedSegments) {
+                const lo = Math.max(seg.start, r.start);
+                const hi = Math.min(seg.end, r.end);
+                if (hi - lo > COVERAGE_EPSILON) {
+                    pieces.push({ lo, hi, rendered: renAcc + (lo - r.start) });
+                }
+                renAcc += r.end - r.start;
+            }
+            pieces.sort((a, b) => a.lo - b.lo);
+
+            let cursor = seg.start;
+            for (const piece of pieces) {
+                // A source range reused twice by the render would overlap here;
+                // first one wins rather than emitting the same clip time twice.
+                const lo = Math.max(piece.lo, cursor);
+                if (piece.hi - lo <= COVERAGE_EPSILON) continue;
+                if (lo - cursor > COVERAGE_EPSILON) {
+                    spans.push({
+                        start: clipAcc + (cursor - seg.start),
+                        end: clipAcc + (lo - seg.start),
+                        rendered: null,
+                    });
+                }
+                spans.push({
+                    start: clipAcc + (lo - seg.start),
+                    end: clipAcc + (piece.hi - seg.start),
+                    rendered: piece.rendered + (lo - piece.lo),
+                });
+                cursor = piece.hi;
+            }
+            if (seg.end - cursor > COVERAGE_EPSILON) {
+                spans.push({
+                    start: clipAcc + (cursor - seg.start),
+                    end: clipAcc + segLen,
+                    rendered: null,
+                });
+            }
+            clipAcc += segLen;
+        }
+        return spans;
+    }, [segments, renderedSegments, framing, renderedFraming]);
+
+    const missingSeconds = useMemo(() => coverage.reduce(
+        (acc, sp) => (sp.rendered === null ? acc + (sp.end - sp.start) : acc), 0), [coverage]);
+
+    // Half-open [start, end), so a position exactly on a seam belongs to the
+    // span that STARTS there — otherwise the playhead reads as being on the next
+    // segment while the picture is still the tail of the previous one. The
+    // epsilon only absorbs rounding on the way in; the very end of the clip
+    // falls back to the last span.
+    const spanIndexAt = useCallback((t) => {
+        const i = coverage.findIndex((sp) => t >= sp.start - COVERAGE_EPSILON && t < sp.end);
+        return i >= 0 ? i : coverage.length - 1;
+    }, [coverage]);
+
+    const clipToRendered = useCallback((t) => {
+        const sp = coverage[spanIndexAt(t)];
+        if (!sp || sp.rendered === null) return null;
+        const offset = Math.max(0, Math.min(t - sp.start, sp.end - sp.start));
+        return sp.rendered + offset;
+    }, [coverage, spanIndexAt]);
+
+    // Used when the native <video> controls are dragged: the file's own time
+    // has to come back onto the clip's timeline.
+    const renderedToClip = useCallback((r) => {
+        for (const sp of coverage) {
+            if (sp.rendered === null) continue;
+            const end = sp.rendered + (sp.end - sp.start);
+            if (r >= sp.rendered - COVERAGE_EPSILON && r <= end + COVERAGE_EPSILON) {
+                return sp.start + (r - sp.rendered);
+            }
+        }
+        return null;
+    }, [coverage]);
+
+    const hasCovered = useMemo(
+        () => coverage.some((sp) => sp.rendered !== null), [coverage]);
+
+    // Keep the playhead out of red. Stopping at the edge is the whole point:
+    // inside one there is no frame to show, so a handle that could sit there
+    // would just be a handle pointing at nothing. Runs of adjacent red spans
+    // (one segment ending unrendered, the next starting unrendered) are treated
+    // as a single wall.
+    // ``path`` distinguishes a drag from a click. Dragging is continuous motion,
+    // so a wall anywhere BETWEEN the two positions stops it — checking only the
+    // destination lets a fast flick tunnel clean through the red. A click is
+    // "go here", so it only has to land somewhere legal.
+    const clampToCovered = useCallback((t, from, { path = false } = {}) => {
+        if (!hasCovered) return t;                      // nothing to stay inside
+        const forward = t >= from;
+
+        let wall = null;
+        if (path) {
+            wall = forward
+                ? coverage.find((sp) => sp.rendered === null
+                    && sp.end > from + COVERAGE_EPSILON && sp.start < t - COVERAGE_EPSILON)
+                : [...coverage].reverse().find((sp) => sp.rendered === null
+                    && sp.start < from - COVERAGE_EPSILON && sp.end > t + COVERAGE_EPSILON);
+        }
+        if (!wall) {
+            const sp = coverage[spanIndexAt(t)];
+            if (!sp || sp.rendered !== null) return t;
+            wall = sp;
+        }
+
+        // Grow it across any neighbouring uncovered spans: one segment ending
+        // unrendered next to another starting unrendered is one wall, not two.
+        let lo = coverage.indexOf(wall);
+        let hi = lo;
+        while (lo > 0 && coverage[lo - 1].rendered === null) lo -= 1;
+        while (hi < coverage.length - 1 && coverage[hi + 1].rendered === null) hi += 1;
+        // A millisecond inside the green, so the position still resolves to the
+        // covered span rather than to the wall it is touching.
+        const near = Math.max(0, coverage[lo].start - 0.001);
+        const far = coverage[hi].end;
+        const hasBefore = lo > 0;
+        const hasAfter = hi < coverage.length - 1;
+
+        if (forward) return hasBefore ? near : (hasAfter ? far : t);
+        return hasAfter ? far : (hasBefore ? near : t);
+    }, [coverage, hasCovered, spanIndexAt]);
+
+    // An edit can leave the handle standing where the file no longer reaches.
+    useEffect(() => {
+        setPlayhead((t) => {
+            const clamped = clampToCovered(t, t);
+            return clamped === t ? t : clamped;
+        });
+    }, [clampToCovered]);
+
+    // ---- scrubbing the clip track ------------------------------------------
+    // Clip time -> source time, walking the segment list. Same reasoning as the
+    // backend's rebase_segments, in the other direction: the clip is the
+    // segments played back to back, so a position on it lands inside whichever
+    // segment's running total covers it.
+    const clipToSource = useCallback((t) => {
+        let acc = 0;
+        for (const seg of segments) {
+            const len = seg.end - seg.start;
+            if (t < acc + len) return seg.start + (t - acc);
+            acc += len;
+        }
+        const last = segments[segments.length - 1];
+        return last ? last.end : 0;
+    }, [segments]);
+
+    // Which coverage span the rendered file is playing through.
+    const playSpanRef = useRef(0);
+
+    // Walk the assembly while the file plays. Everything covered 1:1 (nothing
+    // pending) short-circuits to the old behaviour: no jumps, no bookkeeping.
+    const onClipTimeUpdate = useCallback((e) => {
+        if (dragRef.current?.kind === 'scrub') return;   // seeks report a frame late
+        const v = e.target;
+        if (!dirty) { setPlayhead(v.currentTime); return; }
+
+        let i = playSpanRef.current;
+        let sp = coverage[i];
+        if (!sp) return;
+
+        if (sp.rendered !== null) {
+            const spEnd = sp.rendered + (sp.end - sp.start);
+            if (v.currentTime < spEnd - COVERAGE_EPSILON) {
+                setPlayhead(sp.start + (v.currentTime - sp.rendered));
+                return;
+            }
+        }
+
+        // Past the end of this span: move on to the next one.
+        i += 1;
+        sp = coverage[i];
+        if (!sp) { v.pause(); setPlayhead(totalOf(segments)); return; }
+        playSpanRef.current = i;
+        setPlayhead(sp.start);
+        if (sp.rendered === null) {
+            // Nothing to show here until it is rendered, so stop at the edge
+            // rather than pretending.
+            v.pause();
+            return;
+        }
+        try { v.currentTime = sp.rendered; } catch { /* not seekable yet */ }
+    }, [coverage, dirty, segments]);
+
+    // The native controls scrub the FILE; bring that back onto the clip.
+    const onClipSeeked = useCallback((e) => {
+        if (!dirty || dragRef.current?.kind === 'scrub') return;
+        const t = renderedToClip(e.target.currentTime);
+        if (t === null) return;   // landed on material this edit dropped
+        setPlayhead(t);
+        playSpanRef.current = spanIndexAt(t);
+    }, [dirty, renderedToClip, spanIndexAt]);
+
+    // Refuse to roll from a span the file cannot show — same reason as above.
+    const onClipPlay = useCallback((e) => {
+        if (!dirty) return;
+        const sp = coverage[playSpanRef.current];
+        if (sp && sp.rendered === null) e.target.pause();
+    }, [coverage, dirty]);
+
+    const onScrubMove = useCallback((e) => {
+        const d = dragRef.current;
+        if (!d || d.kind !== 'scrub') return;
+        d.apply(d.at(e.clientX), { path: true });
+    }, []);
+
+    const onScrubUp = useCallback(() => {
+        dragRef.current = null;
+        window.removeEventListener('pointermove', onScrubMove);
+        window.removeEventListener('pointerup', onScrubUp);
+        window.removeEventListener('pointercancel', onScrubUp);
+    }, [onScrubMove]);
+
+    const startClipScrub = (e) => {
+        if (e.button !== undefined && e.button !== 0) return;
+        const rect = clipTrackRef.current?.getBoundingClientRect();
+        if (!rect || !clipTrackSeconds) return;
+        // Same reason as the other tracks: without this Chrome turns the drag
+        // into a text selection and then into a native drag.
+        e.preventDefault();
+        try { e.currentTarget.setPointerCapture?.(e.pointerId); } catch { /* window listeners still fire */ }
+
+        const at = (clientX) => Math.max(0, Math.min(
+            clipTrackSeconds, ((clientX - rect.left) / rect.width) * clipTrackSeconds));
+        // Direction of travel decides which wall a red span stops you at, so it
+        // has to be the last APPLIED position, not the one at pointerdown.
+        let last = playhead;
+        const apply = (raw, { path = false } = {}) => {
+            const t = clampToCovered(raw, last, { path });
+            last = t;
+            setPlayhead(t);
+            // Not "is the file stale" but "does the file hold THIS instant" —
+            // which is what keeps a trim navigable without a re-render.
+            const r = clipToRendered(t);
+            playSpanRef.current = spanIndexAt(t);
+            if (r !== null && videoRef.current) {
+                try { videoRef.current.currentTime = r; } catch { /* not seekable yet */ }
+            }
+            // The source is the only picture available where the file has none.
+            if (sourceOpen) seekSource(clipToSource(t));
+        };
+
+        apply(at(e.clientX));
+        dragRef.current = { kind: 'scrub', at, apply };
+        window.addEventListener('pointermove', onScrubMove);
+        window.addEventListener('pointerup', onScrubUp);
+        window.addEventListener('pointercancel', onScrubUp);
+    };
+
+    // ---- three-point editing: mark in/out, then send to the clip ------------
+    const round3 = (t) => Math.round(t * 1000) / 1000;
+
+    // The marks come off the monitor's own playhead, so "what I am looking at"
+    // and "where the cut lands" are the same instant by construction.
+    const markHere = (which) => {
+        const v = sourceRef.current;
+        if (!v || !Number.isFinite(v.currentTime)) return;
+        (which === 'in' ? setMarkIn : setMarkOut)(round3(v.currentTime));
+    };
+
+    const clearMarks = () => { setMarkIn(null); setMarkOut(null); };
+
+    // Only a usable range counts: both ends marked, and long enough to render.
+    // Order is forgiving — marking OUT before IN still yields the range between.
+    const markRange = useMemo(() => {
+        if (markIn === null || markOut === null) return null;
+        const lo = Math.min(markIn, markOut);
+        const hi = Math.max(markIn, markOut);
+        return hi - lo >= minSeg ? { start: round3(lo), end: round3(hi) } : null;
+    }, [markIn, markOut, minSeg]);
+
+    // 'replace' overwrites the selected segment (make the clip BE this range);
+    // 'insert' drops the range in right after it, rippling the rest along.
+    const sendToClip = (mode) => {
+        if (!markRange) return;
+        if (mode === 'replace') {
+            dispatch({
+                type: 'commit',
+                segments: segments.map((s, i) => (i === selected ? { ...markRange } : s)),
+                select: selected,
+            });
+            return;
+        }
+        if (segments.length >= limits.max_segments) return;
+        const next = segments.slice();
+        next.splice(selected + 1, 0, { ...markRange });
+        dispatch({ type: 'commit', segments: next, select: selected + 1 });
     };
 
     // ---- keyboard -----------------------------------------------------------
@@ -347,6 +779,18 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
             } else if (e.key.toLowerCase() === 's') {
                 e.preventDefault();
                 splitSegment(selected);
+            } else if (sourceOpen && e.key.toLowerCase() === 'i') {
+                e.preventDefault();
+                markHere('in');
+            } else if (sourceOpen && e.key.toLowerCase() === 'o') {
+                e.preventDefault();
+                markHere('out');
+            } else if (sourceOpen && e.key === ',') {
+                e.preventDefault();
+                sendToClip('insert');
+            } else if (sourceOpen && e.key === '.') {
+                e.preventDefault();
+                sendToClip('replace');
             }
         };
         window.addEventListener('keydown', onKey);
@@ -402,13 +846,71 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
     };
 
     // ---- transcript panel data ---------------------------------------------
+    // The panel holds the WHOLE source transcript, not a window around the
+    // segment: extending a cut means reading what is said before and after it.
     const selectedSeg = segments[selected] || null;
-    const panelWords = useMemo(() => {
-        if (!selectedSeg) return [];
-        const lo = selectedSeg.start - WORD_CONTEXT_SECONDS;
-        const hi = selectedSeg.end + WORD_CONTEXT_SECONDS;
-        return words.filter((w) => w.e >= lo && w.s <= hi);
-    }, [words, selectedSeg]);
+    // Deferred so a drag is never blocked repainting a few thousand words —
+    // the highlight settles a frame or two behind the handle, the drag stays
+    // at full rate.
+    const highlightSeg = useDeferredValue(selectedSeg);
+    const anchorIndex = useMemo(() => (
+        selectedSeg ? words.findIndex((w) => w.e > selectedSeg.start) : -1
+    ), [words, selectedSeg]);
+
+    // The word the source monitor is currently on. Binary search — words are
+    // already sorted by start time (recut.transcript_words does that). During
+    // silence the previous word stays lit rather than blinking off: "you are
+    // here" is more useful than a strictly correct nothing.
+    const activeWordIndex = useMemo(() => {
+        let lo = 0;
+        let hi = words.length - 1;
+        let best = -1;
+        while (lo <= hi) {
+            const mid = (lo + hi) >> 1;
+            if (words[mid].s <= sourceTime) { best = mid; lo = mid + 1; } else hi = mid - 1;
+        }
+        return best;
+    }, [words, sourceTime]);
+
+    const selectedWordIndex = useMemo(() => (
+        selectedWord ? words.findIndex((w) => w.s === selectedWord.s && w.e === selectedWord.e) : -1
+    ), [words, selectedWord]);
+
+    const chunks = useMemo(() => {
+        const out = [];
+        for (let i = 0; i < words.length; i += CHUNK_WORDS) {
+            out.push({ offset: i, items: words.slice(i, i + CHUNK_WORDS) });
+        }
+        return out;
+    }, [words]);
+
+    // Direct scrollTop, not scrollIntoView: the latter also scrolls every
+    // ancestor, which would yank the whole column around mid-drag.
+    const scrollTranscriptTo = useCallback((selector) => {
+        const box = transcriptRef.current;
+        if (!box) return;
+        const el = box.querySelector(selector);
+        if (!el) return;
+        box.scrollTop = Math.max(0, el.offsetTop - box.clientHeight / 2);
+    }, []);
+
+    // Two scrollers, one policy, so they cannot fight: picking a segment jumps
+    // to it, and anything that moves the monitor (playback, a track drag, a
+    // seek) takes over from there. Deliberately NOT keyed on the segment's
+    // start, which changes every frame of a drag.
+    useEffect(() => {
+        scrollTranscriptTo('[data-anchor="1"]');
+    }, [selected, words.length, scrollTranscriptTo]);
+
+    useEffect(() => {
+        scrollTranscriptTo('[data-active="1"]');
+    }, [activeWordIndex, scrollTranscriptTo]);
+
+    // Stable identity keeps every untouched chunk out of the re-render.
+    const pickWord = useCallback((w) => {
+        setSelectedWord((prev) => (prev && prev.s === w.s && prev.e === w.e ? null : w));
+        seekSource(w.s);
+    }, [seekSource]);
 
     // ---- render -------------------------------------------------------------
     if (loadError) {
@@ -441,18 +943,122 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
         runningOffset += s.end - s.start;
         return { seg: s, i, left, width };
     });
-    const renderedTotal = renderedSegments ? totalOf(renderedSegments) : 0;
+
+    // The source track lives under the source monitor. With no source at all
+    // there is no monitor to sit under, so it moves below the clip track: it
+    // still explains why trims are pinned to the original range.
+    const sourceTrack = (
+        <div className="shrink-0 select-none">
+            <div className="flex items-center justify-between mb-1.5 gap-3">
+                <p className="readout">
+                    SOURCE · {fmt(sourceDuration)}{edl.source.duration_estimated ? ' (EST.)' : ''}
+                    {!sourceAvailable && ' · EXPIRED — TRIMS LIMITED TO THE ORIGINAL RANGE'}
+                </p>
+                {sourceAvailable && (
+                    <p className="readout hidden xl:block truncate">
+                        DRAG EMPTY SPACE TO MARK IN/OUT · BLOCK TO MOVE · EDGES TO TRIM
+                    </p>
+                )}
+            </div>
+            <div
+                ref={sourceTrackRef}
+                onPointerDown={startGhostDrag}
+                className={`relative h-8 rounded-input border overflow-hidden touch-none ${sourceAvailable ? 'bg-paper border-rule cursor-crosshair' : 'bg-paper border-rule opacity-60'}`}
+            >
+                {/* canonical range marker */}
+                {sourceDuration > 0 && (
+                    <div
+                        className="absolute top-0 bottom-0 border-x border-rule2 bg-paper3/60 pointer-events-none"
+                        style={{
+                            left: `${(canonical.start / sourceDuration) * 100}%`,
+                            width: `${((canonical.end - canonical.start) / sourceDuration) * 100}%`,
+                        }}
+                    />
+                )}
+                {sourceDuration > 0 && segments.map((seg, i) => (
+                    <div
+                        key={i}
+                        // Body drag slides the segment along the source without
+                        // changing its duration; the edges trim it.
+                        onPointerDown={(e) => startTrimDrag(e, i, 'move', sourceTrackRef.current, sourceDuration)}
+                        className={`absolute top-1 bottom-1 rounded-[4px] touch-none cursor-grab active:cursor-grabbing ${i === selected ? 'ring-1 ring-[color:var(--color-accent)]' : ''}`}
+                        style={{
+                            left: `${(seg.start / sourceDuration) * 100}%`,
+                            width: `${Math.max(((seg.end - seg.start) / sourceDuration) * 100, 0.4)}%`,
+                            // A short segment on a 14-minute source is a sliver;
+                            // without a floor there is nothing left to grab.
+                            minWidth: '14px',
+                            background: SEGMENT_COLORS[i % SEGMENT_COLORS.length],
+                        }}
+                        title={`#${i + 1} · ${fmt(seg.start)} → ${fmt(seg.end)} — drag to move, edges to trim`}
+                    >
+                        {/* Capped at a third each so the middle stays grabbable
+                            however narrow the block gets. */}
+                        <div
+                            onPointerDown={(e) => startTrimDrag(e, i, 'start', sourceTrackRef.current, sourceDuration)}
+                            className="absolute left-0 top-0 bottom-0 w-1.5 max-w-[33%] touch-none cursor-ew-resize rounded-l-[4px] bg-ink/35"
+                        />
+                        <div
+                            onPointerDown={(e) => startTrimDrag(e, i, 'end', sourceTrackRef.current, sourceDuration)}
+                            className="absolute right-0 top-0 bottom-0 w-1.5 max-w-[33%] touch-none cursor-ew-resize rounded-r-[4px] bg-ink/35"
+                        />
+                    </div>
+                ))}
+                {markRange && sourceDuration > 0 && !ghost && (
+                    <div
+                        className="absolute inset-y-0 border-x-2 border-brass bg-brass/15 pointer-events-none"
+                        style={{
+                            left: `${(markRange.start / sourceDuration) * 100}%`,
+                            width: `${((markRange.end - markRange.start) / sourceDuration) * 100}%`,
+                        }}
+                    />
+                )}
+                {/* A lone mark still has to be visible, or setting IN and
+                    then hunting for OUT gives no feedback at all. */}
+                {sourceDuration > 0 && !ghost && !markRange && [markIn, markOut].map((t, i) => (
+                    t === null ? null : (
+                        <div
+                            key={i}
+                            className="absolute inset-y-0 w-0.5 bg-brass pointer-events-none"
+                            style={{ left: `${(t / sourceDuration) * 100}%` }}
+                        />
+                    )
+                ))}
+                {/* the source monitor's own playhead */}
+                {sourceOpen && sourceDuration > 0 && (
+                    <div
+                        className="absolute top-0 bottom-0 w-px bg-ink pointer-events-none"
+                        style={{ left: `${(Math.min(sourceTime, sourceDuration) / sourceDuration) * 100}%` }}
+                    />
+                )}
+                {ghost && sourceDuration > 0 && (
+                    <div
+                        className="absolute top-1 bottom-1 rounded-[4px] bg-ink/40 border border-dashed border-ink pointer-events-none"
+                        style={{
+                            left: `${(ghost.start / sourceDuration) * 100}%`,
+                            width: `${((ghost.end - ghost.start) / sourceDuration) * 100}%`,
+                        }}
+                    />
+                )}
+            </div>
+            <div className="flex justify-between mt-1">
+                <span className="readout">0:00</span>
+                <span className="readout">{fmt(sourceDuration / 2)}</span>
+                <span className="readout">{fmt(sourceDuration)}</span>
+            </div>
+        </div>
+    );
 
     return (
         <div className="fixed inset-0 z-[110] bg-paper flex flex-col animate-fade">
             {/* header */}
-            <div className="px-4 sm:px-6 pt-5 pb-4 border-b border-rule flex items-start justify-between gap-4 shrink-0">
+            <div className="px-4 sm:px-6 pt-4 pb-3 border-b border-rule flex items-start justify-between gap-4 shrink-0">
                 <div className="min-w-0">
                     <p className="eyebrow mb-1">EDITOR · CLIP {clipIndex + 1}</p>
                     <h2 className="font-display lowercase text-2xl text-ink truncate">edit clip</h2>
                     {clipTitle && <p className="text-xs text-muted truncate mt-0.5">{clipTitle}</p>}
                 </div>
-                <div className="flex items-center gap-4 shrink-0">
+                <div className="flex items-center gap-3 shrink-0">
                     <div className="text-right">
                         <p className="readout">DURATION · {fmt(total)}</p>
                         <p className="readout mt-1">
@@ -460,6 +1066,18 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
                             {edl.rerender_minutes > 0 && ` · ≈${Math.max(1, Math.ceil(total / 60))} MIN`}
                         </p>
                     </div>
+                    {sourceAvailable && (
+                        <button
+                            onClick={() => setShowSource((v) => !v)}
+                            title={showSource
+                                ? 'put the source monitor away and edit the clip on its own'
+                                : 'bring back the source monitor, its transcript and in/out marking'}
+                            className="btn-quiet text-xs py-1.5 px-3 flex items-center gap-1.5 lowercase"
+                        >
+                            {showSource ? <PanelLeftClose size={14} /> : <PanelLeft size={14} />}
+                            {showSource ? 'hide source' : 'show source'}
+                        </button>
+                    )}
                     {confirmClose ? (
                         <div className="flex items-center gap-2">
                             <span className="text-xs text-warn lowercase">discard changes?</span>
@@ -478,28 +1096,238 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
                 </div>
             </div>
 
-            {/* main */}
-            <div className="flex-1 min-h-0 flex flex-col md:flex-row gap-6 px-4 sm:px-6 py-5 overflow-hidden">
-                {/* preview */}
-                <div className="flex-1 min-w-0 flex items-center justify-center">
-                    <div className="h-full max-h-full aspect-[9/16] bg-black rounded-card border border-rule overflow-hidden relative">
-                        <video
-                            ref={videoRef}
-                            src={previewUrl}
-                            controls
-                            playsInline
-                            className="w-full h-full object-contain"
-                            onTimeUpdate={(e) => setPlayhead(e.target.currentTime)}
-                        />
+            {/* main — three columns above xl, stacked below. select-none/touch-none
+                keep the browser from turning a drag on a track into a text
+                selection or a page pan. */}
+            <div className="flex-1 min-h-0 flex flex-col xl:flex-row gap-4 px-4 sm:px-6 py-4 overflow-y-auto xl:overflow-hidden select-none">
+
+                {/* ---- column 1 · source ---- */}
+                {sourceOpen && (
+                    <div className="flex-1 min-w-0 flex flex-col min-h-0 gap-2">
+                        <p className="eyebrow shrink-0">Source</p>
+                        {/* The black hugs the picture instead of the column: a wide
+                            box around a short 16:9 frame is exactly the dead space
+                            this layout set out to remove. */}
+                        <div className="flex-1 min-h-0 min-w-0 flex items-center justify-center">
+                            <video
+                                ref={sourceRef}
+                                src={getApiUrl(edl.source.url)}
+                                controls
+                                playsInline
+                                preload="metadata"
+                                onLoadedMetadata={applySeek}
+                                onTimeUpdate={(e) => setSourceTime(e.target.currentTime)}
+                                className="h-full w-auto max-w-full max-h-full bg-black rounded-card border border-rule"
+                            />
+                        </div>
+
+                        {sourceTrack}
+
+                        {/* Two steps, shown as two: pick a range on the source, then
+                            put it in the clip. Six controls in one undifferentiated
+                            row read as six unrelated buttons. */}
+                        <div className="shrink-0 rounded-input border border-rule bg-paper2 p-2 flex items-stretch gap-3">
+                            <div className="flex items-center gap-1.5 flex-1 min-w-0">
+                                <span className="readout shrink-0 text-muted">1 · MARK</span>
+                                <button onClick={() => markHere('in')} className="btn-quiet text-[11px] py-1 px-2 flex items-center gap-1 shrink-0">
+                                    <ChevronsRight size={12} /> in <span className="text-muted">i</span>
+                                </button>
+                                <button onClick={() => markHere('out')} className="btn-quiet text-[11px] py-1 px-2 flex items-center gap-1 shrink-0">
+                                    <ChevronsLeft size={12} /> out <span className="text-muted">o</span>
+                                </button>
+                                <p className={`readout px-1 truncate ${markRange ? 'text-ink' : ''}`}>
+                                    {markIn === null ? '—:——' : fmt(markIn)}
+                                    {' → '}{markOut === null ? '—:——' : fmt(markOut)}
+                                    {markRange && ` · ${fmt(markRange.end - markRange.start)}`}
+                                    {markIn !== null && markOut !== null && !markRange
+                                        && ` · UNDER ${minSeg}S`}
+                                </p>
+                                <button
+                                    onClick={clearMarks}
+                                    disabled={markIn === null && markOut === null}
+                                    className="p-1 rounded-input text-muted hover:text-ink hover:bg-paper3 disabled:opacity-40 shrink-0"
+                                    aria-label="clear in and out marks"
+                                >
+                                    <X size={13} />
+                                </button>
+                            </div>
+
+                            <div className="w-px bg-[color:var(--color-rule-2)] shrink-0" />
+
+                            <div className="flex items-center gap-1.5 shrink-0">
+                                <span className="readout text-muted">2 · SEND</span>
+                                <button
+                                    onClick={() => sendToClip('replace')}
+                                    disabled={!markRange}
+                                    title="the selected segment becomes this range (.)"
+                                    className="btn-primary text-[11px] py-1.5 px-2 disabled:opacity-40"
+                                >
+                                    replace #{selected + 1}
+                                </button>
+                                <button
+                                    onClick={() => sendToClip('insert')}
+                                    disabled={!markRange || segments.length >= limits.max_segments}
+                                    title="add this range as a new segment after the selected one (,)"
+                                    className="btn-quiet text-[11px] py-1.5 px-2 disabled:opacity-40"
+                                >
+                                    insert after #{selected + 1}
+                                </button>
+                            </div>
+                        </div>
+
+                        {/* transcript of the whole source */}
+                        <div className="shrink-0 h-[30%] min-h-[9rem] flex flex-col">
+                            <div className="flex items-baseline justify-between mb-1.5 gap-2 shrink-0">
+                                <p className="eyebrow">Transcript · full source</p>
+                                <span className="readout shrink-0">CLICK A WORD TO GO THERE</span>
+                            </div>
+                            {words.length === 0 ? (
+                                <p className="text-xs text-muted lowercase">this job kept no transcript</p>
+                            ) : (
+                                <div
+                                    ref={transcriptRef}
+                                    className="relative flex-1 min-h-0 flex flex-wrap content-start gap-x-1 gap-y-1.5 overflow-y-auto custom-scrollbar pr-1"
+                                >
+                                    {chunks.map((c) => {
+                                        const first = c.items[0].s;
+                                        const last = c.items[c.items.length - 1].e;
+                                        // 'none' and 'all' are stable primitives, so only the
+                                        // one or two slices straddling a segment edge repaint
+                                        // while a trim handle is being dragged.
+                                        let lit = 'none';
+                                        if (highlightSeg && !(last <= highlightSeg.start || first >= highlightSeg.end)) {
+                                            lit = (first >= highlightSeg.start && last <= highlightSeg.end)
+                                                ? 'all' : highlightSeg;
+                                        }
+                                        const local = (idx) => (
+                                            idx >= c.offset && idx < c.offset + c.items.length ? idx - c.offset : -1
+                                        );
+                                        return (
+                                            <TranscriptChunk
+                                                key={c.offset}
+                                                items={c.items}
+                                                offset={c.offset}
+                                                lit={lit}
+                                                active={local(activeWordIndex)}
+                                                anchorAt={local(anchorIndex)}
+                                                selectedAt={local(selectedWordIndex)}
+                                                onPick={pickWord}
+                                            />
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                )}
+
+                {/* ---- column 2 · program ---- */}
+                {/* Sized to the 9:16 preview plus enough track to aim with, rather
+                    than an equal share: a wider column here is just black beside a
+                    height-bound video, and that width is worth more to the source.
+                    With the source away it takes everything, which is what gives
+                    the clip track its full precision back. */}
+                <div className={`flex flex-col min-h-0 gap-2 ${sourceOpen ? 'xl:w-[26rem] 2xl:w-[30rem] xl:shrink-0' : 'flex-1'}`}>
+                    <div className="flex items-center justify-between gap-2 shrink-0">
+                        <p className="eyebrow">Program</p>
                         {dirty && (
-                            <div className="absolute top-2 left-2 badge-warn">preview shows the last render</div>
+                            <span className="badge-warn">
+                                {missingSeconds > COVERAGE_EPSILON
+                                    ? `${fmt(missingSeconds)} needs rendering`
+                                    : 'previewing the edit · re-render to keep it'}
+                            </span>
                         )}
                     </div>
+                    <div className="flex-1 min-h-0 flex items-center justify-center">
+                        <div className="h-full max-h-full aspect-[9/16] bg-black rounded-card border border-rule overflow-hidden">
+                            <video
+                                ref={videoRef}
+                                src={previewUrl}
+                                controls
+                                playsInline
+                                className="w-full h-full object-contain"
+                                onTimeUpdate={onClipTimeUpdate}
+                                onSeeked={onClipSeeked}
+                                onPlay={onClipPlay}
+                            />
+                        </div>
+                    </div>
+
+                    {/* clip track */}
+                    <div className="shrink-0 select-none">
+                        <div className="flex items-center justify-between mb-1.5 gap-3">
+                            <p className="readout">CLIP · {fmt(total)}</p>
+                            {dirty && (
+                                <p className="readout truncate">
+                                    {missingSeconds > COVERAGE_EPSILON
+                                        ? `RED · ${fmt(missingSeconds)} NOT RENDERED YET`
+                                        : 'PREVIEWING THE EDIT'}
+                                </p>
+                            )}
+                        </div>
+                        <div
+                            ref={clipTrackRef}
+                            onPointerDown={startClipScrub}
+                            className="relative h-12 rounded-input bg-paper border border-rule overflow-hidden touch-none cursor-pointer"
+                        >
+                            {blocks.map(({ seg, i, left, width }) => (
+                                <div
+                                    key={i}
+                                    onPointerDown={() => dispatch({ type: 'select', index: i })}
+                                    className={`absolute top-1 bottom-1 rounded-[6px] border ${i === selected ? 'border-[color:var(--color-accent)]' : 'border-transparent'} ${outOfRange(seg) ? 'border-[color:var(--color-danger)]' : ''}`}
+                                    style={{ left: `${left}%`, width: `${width}%`, background: `color-mix(in oklab, ${SEGMENT_COLORS[i % SEGMENT_COLORS.length]} 28%, transparent)` }}
+                                >
+                                    <span className="absolute inset-0 flex items-center justify-center readout pointer-events-none select-none">
+                                        #{i + 1} · {fmt(seg.end - seg.start)}
+                                    </span>
+                                    {/* trim handles */}
+                                    <div
+                                        onPointerDown={(e) => startTrimDrag(e, i, 'start', clipTrackRef.current, clipTrackSeconds)}
+                                        className="absolute left-0 top-0 bottom-0 w-2 touch-none cursor-ew-resize rounded-l-[6px]"
+                                        style={{ background: SEGMENT_COLORS[i % SEGMENT_COLORS.length] }}
+                                    />
+                                    <div
+                                        onPointerDown={(e) => startTrimDrag(e, i, 'end', clipTrackRef.current, clipTrackSeconds)}
+                                        className="absolute right-0 top-0 bottom-0 w-2 touch-none cursor-ew-resize rounded-r-[6px]"
+                                        style={{ background: SEGMENT_COLORS[i % SEGMENT_COLORS.length] }}
+                                    />
+                                </div>
+                            ))}
+                            {/* Render status, as an NLE draws it: red is material the
+                                last render never saw, so there is no frame to show
+                                until it is rendered. Everything else plays straight
+                                out of the existing file. */}
+                            {dirty && coverage.map((sp, i) => (
+                                <div
+                                    key={i}
+                                    className={`absolute top-0 h-1 pointer-events-none ${
+                                        sp.rendered === null ? 'bg-danger' : 'bg-ok/50'}`}
+                                    style={{
+                                        left: `${(sp.start / clipTrackSeconds) * 100}%`,
+                                        width: `${((sp.end - sp.start) / clipTrackSeconds) * 100}%`,
+                                    }}
+                                />
+                            ))}
+                            {/* A handle, not a hairline: the same solid, grabbable
+                                shape the source track uses, so this reads as
+                                something you drive rather than a marker that
+                                happens to move. No handler of its own — the
+                                pointerdown bubbles to the track, which already
+                                scrubs from the pointer position. */}
+                            <div
+                                title="drag to move through the clip"
+                                className="absolute top-1 bottom-1 w-2.5 -ml-[5px] rounded-[4px] bg-ink border border-paper cursor-grab active:cursor-grabbing"
+                                style={{ left: `${(Math.min(playhead, clipTrackSeconds) / clipTrackSeconds) * 100}%` }}
+                            />
+                        </div>
+                    </div>
+
+                    {!sourceAvailable && sourceTrack}
                 </div>
 
-                {/* rail */}
-                <div className="w-full md:w-[24rem] shrink-0 flex flex-col min-h-0">
-                    <div className="flex-1 overflow-y-auto custom-scrollbar pr-1 space-y-5">
+                {/* ---- column 3 · controls ---- */}
+                <div className="w-full xl:w-[21rem] shrink-0 flex flex-col min-h-0">
+                    <div className="flex-1 xl:overflow-y-auto custom-scrollbar pr-1 space-y-5">
                         {/* segments */}
                         <div>
                             <div className="flex items-center justify-between mb-2">
@@ -541,6 +1369,9 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
                                             <span className="readout ml-auto">{fmt(seg.end - seg.start)}</span>
                                         </div>
                                         <div className="flex items-center gap-1 mt-2">
+                                            {sourceOpen && (
+                                                <button className="p-1 rounded-input text-muted hover:text-ink hover:bg-paper" onClick={(e) => { e.stopPropagation(); dispatch({ type: 'select', index: i }); seekSource(seg.start); }} aria-label="show this segment in the source monitor"><Film size={13} /></button>
+                                            )}
                                             <button className="p-1 rounded-input text-muted hover:text-ink hover:bg-paper disabled:opacity-45" disabled={i === 0} onClick={(e) => { e.stopPropagation(); moveSegment(i, -1); }} aria-label="move up"><ChevronUp size={13} /></button>
                                             <button className="p-1 rounded-input text-muted hover:text-ink hover:bg-paper disabled:opacity-45" disabled={i === segments.length - 1} onClick={(e) => { e.stopPropagation(); moveSegment(i, 1); }} aria-label="move down"><ChevronDown size={13} /></button>
                                             <button className="p-1 rounded-input text-muted hover:text-ink hover:bg-paper disabled:opacity-45" disabled={seg.end - seg.start < minSeg * 2 || segments.length >= limits.max_segments} onClick={(e) => { e.stopPropagation(); splitSegment(i); }} aria-label="split segment"><Scissors size={13} /></button>
@@ -623,62 +1454,14 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
                             </label>
                         </div>
 
-                        {/* source monitor */}
-                        {sourceAvailable && (
-                            <div>
-                                <button onClick={() => setShowSource((v) => !v)} className="w-full flex items-center justify-between mb-2">
-                                    <p className="eyebrow">Source monitor</p>
-                                    <Film size={13} className={showSource ? 'text-brass' : 'text-muted'} />
-                                </button>
-                                {showSource && (
-                                    <div className="bg-black rounded-card border border-rule overflow-hidden">
-                                        <video ref={sourceRef} src={getApiUrl(edl.source.url)} controls playsInline className="w-full max-h-48 object-contain" />
-                                        <div className="flex flex-wrap gap-1 p-2 bg-paper2">
-                                            {segments.map((seg, i) => (
-                                                <button
-                                                    key={i}
-                                                    onClick={() => { if (sourceRef.current) { sourceRef.current.currentTime = seg.start; sourceRef.current.play().catch(() => {}); } }}
-                                                    className="px-2 py-1 rounded-input border border-rule text-[11px] text-ink2 hover:bg-paper3 lowercase"
-                                                >
-                                                    #{i + 1} · {fmt(seg.start)}
-                                                </button>
-                                            ))}
-                                        </div>
-                                    </div>
-                                )}
-                            </div>
-                        )}
-
-                        {/* transcript */}
+                        {/* keyboard legend — moved off the clip track, which no longer
+                            has the width for it */}
                         <div>
-                            <p className="eyebrow mb-2">Transcript · segment #{selected + 1}</p>
-                            {panelWords.length === 0 ? (
-                                <p className="text-xs text-muted lowercase">no words near this segment</p>
-                            ) : (
-                                <div className="flex flex-wrap gap-x-1 gap-y-1.5 max-h-40 overflow-y-auto custom-scrollbar pr-1">
-                                    {panelWords.map((w, i) => {
-                                        const inside = selectedSeg && w.e > selectedSeg.start && w.s < selectedSeg.end;
-                                        const isSel = selectedWord && selectedWord.s === w.s && selectedWord.e === w.e;
-                                        return (
-                                            <button
-                                                key={`${w.s}-${i}`}
-                                                onClick={() => setSelectedWord(isSel ? null : w)}
-                                                title={`${fmt(w.s)} – ${fmt(w.e)}`}
-                                                className={`px-1 py-0.5 rounded text-xs transition-colors ${isSel ? 'bg-brass text-brassink' : inside ? 'text-ink hover:bg-paper3' : 'text-muted hover:bg-paper3'}`}
-                                            >
-                                                {w.w}
-                                            </button>
-                                        );
-                                    })}
-                                </div>
-                            )}
-                            {selectedWord && selectedSeg && (
-                                <div className="flex items-center gap-2 mt-2">
-                                    <span className="readout">“{selectedWord.w}” · {fmt(selectedWord.s)}</span>
-                                    <button className="btn-quiet text-[11px] py-1 px-2" onClick={() => { setSegment(selected, { start: selectedWord.s }, { snap: false }); setSelectedWord(null); }}>start here</button>
-                                    <button className="btn-quiet text-[11px] py-1 px-2" onClick={() => { setSegment(selected, { end: selectedWord.e }, { snap: false }); setSelectedWord(null); }}>end here</button>
-                                </div>
-                            )}
+                            <p className="eyebrow mb-2">Shortcuts</p>
+                            <p className="readout leading-relaxed">
+                                SPACE PLAY · S SPLIT · ⌫ DELETE · ⌘Z UNDO
+                                {sourceOpen && ' · I MARK IN · O MARK OUT · , INSERT · . REPLACE'}
+                            </p>
                         </div>
                     </div>
 
@@ -707,102 +1490,46 @@ export default function ClipEditor({ jobId, clipIndex, clipTitle, onClose, onRer
                     </div>
                 </div>
             </div>
-
-            {/* timeline */}
-            <div className="shrink-0 border-t border-rule px-4 sm:px-6 py-4 space-y-3 bg-paper2">
-                {/* clip track */}
-                <div>
-                    <div className="flex items-center justify-between mb-1.5">
-                        <p className="readout">CLIP · {fmt(total)}</p>
-                        <p className="readout hidden sm:block">SPACE PLAY · S SPLIT · ⌫ DELETE · ⌘Z UNDO</p>
-                    </div>
-                    <div ref={clipTrackRef} className="relative h-12 rounded-input bg-paper border border-rule overflow-hidden">
-                        {blocks.map(({ seg, i, left, width }) => (
-                            <div
-                                key={i}
-                                onPointerDown={() => dispatch({ type: 'select', index: i })}
-                                className={`absolute top-1 bottom-1 rounded-[6px] border ${i === selected ? 'border-[color:var(--color-accent)]' : 'border-transparent'} ${outOfRange(seg) ? 'border-[color:var(--color-danger)]' : ''}`}
-                                style={{ left: `${left}%`, width: `${width}%`, background: `color-mix(in oklab, ${SEGMENT_COLORS[i % SEGMENT_COLORS.length]} 28%, transparent)` }}
-                            >
-                                <span className="absolute inset-0 flex items-center justify-center readout pointer-events-none select-none">
-                                    #{i + 1} · {fmt(seg.end - seg.start)}
-                                </span>
-                                {/* trim handles */}
-                                <div
-                                    onPointerDown={(e) => startTrimDrag(e, i, 'start', clipTrackRef.current, clipTrackSeconds)}
-                                    className="absolute left-0 top-0 bottom-0 w-2 cursor-ew-resize rounded-l-[6px]"
-                                    style={{ background: SEGMENT_COLORS[i % SEGMENT_COLORS.length] }}
-                                />
-                                <div
-                                    onPointerDown={(e) => startTrimDrag(e, i, 'end', clipTrackRef.current, clipTrackSeconds)}
-                                    className="absolute right-0 top-0 bottom-0 w-2 cursor-ew-resize rounded-r-[6px]"
-                                    style={{ background: SEGMENT_COLORS[i % SEGMENT_COLORS.length] }}
-                                />
-                            </div>
-                        ))}
-                        {/* playhead over the last rendered recipe */}
-                        {!dirty && renderedTotal > 0 && playhead <= renderedTotal && (
-                            <div className="absolute top-0 bottom-0 w-px bg-ink pointer-events-none" style={{ left: `${(playhead / renderedTotal) * 100}%` }} />
-                        )}
-                    </div>
-                </div>
-
-                {/* source track */}
-                <div>
-                    <div className="flex items-center justify-between mb-1.5">
-                        <p className="readout">
-                            SOURCE · {fmt(sourceDuration)}{edl.source.duration_estimated ? ' (EST.)' : ''}
-                            {!sourceAvailable && ' · EXPIRED — TRIMS LIMITED TO THE ORIGINAL RANGE'}
-                        </p>
-                        {sourceAvailable && segments.length < limits.max_segments && (
-                            <p className="readout hidden sm:block">DRAG ON EMPTY SPACE TO ADD A SEGMENT</p>
-                        )}
-                    </div>
-                    <div
-                        ref={sourceTrackRef}
-                        onPointerDown={startGhostDrag}
-                        className={`relative h-8 rounded-input border overflow-hidden ${sourceAvailable ? 'bg-paper border-rule cursor-crosshair' : 'bg-paper border-rule opacity-60'}`}
-                    >
-                        {/* canonical range marker */}
-                        {sourceDuration > 0 && (
-                            <div
-                                className="absolute top-0 bottom-0 border-x border-rule2 bg-paper3/60 pointer-events-none"
-                                style={{
-                                    left: `${(canonical.start / sourceDuration) * 100}%`,
-                                    width: `${((canonical.end - canonical.start) / sourceDuration) * 100}%`,
-                                }}
-                            />
-                        )}
-                        {sourceDuration > 0 && segments.map((seg, i) => (
-                            <div
-                                key={i}
-                                onPointerDown={(e) => { e.stopPropagation(); dispatch({ type: 'select', index: i }); }}
-                                className={`absolute top-1 bottom-1 rounded-[4px] cursor-pointer ${i === selected ? 'ring-1 ring-[color:var(--color-accent)]' : ''}`}
-                                style={{
-                                    left: `${(seg.start / sourceDuration) * 100}%`,
-                                    width: `${Math.max(((seg.end - seg.start) / sourceDuration) * 100, 0.4)}%`,
-                                    background: SEGMENT_COLORS[i % SEGMENT_COLORS.length],
-                                }}
-                                title={`#${i + 1} · ${fmt(seg.start)} → ${fmt(seg.end)}`}
-                            />
-                        ))}
-                        {ghost && sourceDuration > 0 && (
-                            <div
-                                className="absolute top-1 bottom-1 rounded-[4px] bg-ink/40 border border-dashed border-ink pointer-events-none"
-                                style={{
-                                    left: `${(ghost.start / sourceDuration) * 100}%`,
-                                    width: `${((ghost.end - ghost.start) / sourceDuration) * 100}%`,
-                                }}
-                            />
-                        )}
-                    </div>
-                    <div className="flex justify-between mt-1">
-                        <span className="readout">0:00</span>
-                        <span className="readout">{fmt(sourceDuration / 2)}</span>
-                        <span className="readout">{fmt(sourceDuration)}</span>
-                    </div>
-                </div>
-            </div>
         </div>
     );
 }
+
+
+// One slice of the transcript. Memoised because the whole transcript is on
+// screen: repainting a couple of thousand words costs ~66ms, and the source
+// monitor fires timeupdate about four times a second while it plays. Sliced,
+// a moving playhead repaints ~50 words instead of all of them.
+//
+// It returns a Fragment rather than a wrapper element so the words stay direct
+// children of the scroll box — the flex-wrap layout and the anchor's offsetTop
+// both depend on that.
+const TranscriptChunk = React.memo(function TranscriptChunk({
+    items, offset, lit, active, anchorAt, selectedAt, onPick,
+}) {
+    return (
+        <>
+            {items.map((w, i) => {
+                const inside = lit === 'all'
+                    || (lit !== 'none' && w.e > lit.start && w.s < lit.end);
+                const isActive = i === active;
+                const isSel = i === selectedAt;
+                return (
+                    <button
+                        key={`${w.s}-${offset + i}`}
+                        data-anchor={i === anchorAt ? '1' : undefined}
+                        data-active={isActive ? '1' : undefined}
+                        onClick={() => onPick(w)}
+                        title={`${fmt(w.s)} – ${fmt(w.e)}`}
+                        className={`px-1 py-0.5 rounded text-xs transition-colors ${
+                            isSel ? 'bg-brass text-brassink'
+                                : isActive ? 'bg-brass/30 text-ink'
+                                    : inside ? 'text-ink hover:bg-paper3'
+                                        : 'text-muted hover:bg-paper3'}`}
+                    >
+                        {w.w}
+                    </button>
+                );
+            })}
+        </>
+    );
+});

--- a/tests/test_rerender_endpoint.py
+++ b/tests/test_rerender_endpoint.py
@@ -114,7 +114,8 @@ class TestGetEdl:
         assert data["has_captions"] is False
         assert data["source"]["available"] is True
         assert data["source"]["url"] == f"/api/source/{JOB_ID}"
-        # All three transcript words sit within the ±context window.
+        # The editor gets the whole source transcript, not a window around
+        # the clip: a cut can only be extended into words it was sent.
         assert [w["w"] for w in data["words"]] == ["hello", "world", "again"]
         assert data["limits"]["max_segments"] == recut.MAX_SEGMENTS
         # Self-host meters nothing.


### PR DESCRIPTION
## What this is

I have been cutting podcast clips with the self-hosted build for a few weeks, and kept hitting the same wall: the clip editor could describe an edit but not let me *judge* one. This rebuilds it into a three-point editing surface — mark in/out on the source, send the range to the clip, scrub the result — and makes the timeline honest about which parts of a pending edit the last render can already show.

Everything below is one file plus eleven lines of `app.py`. No new dependencies, no schema changes, no new endpoints.

---

## The problem, measured

Three things were wrong, and each turned out to have a concrete cause rather than a vague "feels clunky".

**1. The source track ignored drags in Chrome.** Not a rendering bug — there was no drag to ignore. The orange block's `onPointerDown` only selected the segment, and neither it nor the empty track called `preventDefault()`. So Chrome ran its default action: a text selection over the track's labels. The follow-up gesture then became a native drag-and-drop of that selection, which swallows every subsequent pointer event and paints the not-allowed cursor. A user sees a bar that sometimes shows 🚫 and never moves.

**2. You were editing blind.** The editor showed times, not pictures. Changing a segment updated numbers on screen while the preview kept playing the last render, with a small badge as the only hint. There was no way to answer "who is talking here?" or "does this cut land before or after the sentence?" without leaving the editor.

**3. The layout spent its space on the wrong thing.** At 1908×892 the preview column was 1452px wide for a 324px video — **1128px of black, 59% of the window** — while the source monitor was squeezed into 336px and the transcript sat below the fold at 336×160.

That third one has a cause worth stating, because it makes the fix free: **a 9:16 preview is bound by height, not width.** 570px tall × 9/16 = 324px wide. Taking width away from it does not shrink it at all until you reach 324px. All that horizontal space was unusable by the element it was reserved for.

---

## What changed, and why

### Three-point editing instead of implicit gestures

`mark in` / `mark out` (keys `i` / `o`) take the source monitor's own playhead, so what is on screen and where the cut lands are the same instant by construction. Then `replace #N` (`.`) makes the selected segment *be* that range, or `insert after #N` (`,`) drops it in after and ripples the rest along.

Order is forgiving — marking OUT before IN still yields the range between them — and the marked range is drawn on the source track: a brass band when both ends are set, a single line while only one is, because otherwise you set IN and then hunt for OUT with no feedback at all.

**Dragging empty track now marks a range instead of appending a segment.** That gesture previously committed a segment silently, which nobody guesses; the scissors (split) was the only control that *looked* like "make a cut", and it does something else entirely. One concept — propose a range, then send it — beats two ways to reach the same state.

The same reasoning removed `start here` / `end here` from the transcript. They called `setSegment` directly and reached exactly what mark + replace reaches. Two paths to one outcome is the thing that made the panel read as redundant.

### The source monitor as the thing you aim with

Every gesture on the source track drives it: the block body and both trim handles seek to the edge under the pointer, painting a range follows the moving end, and landing anywhere on the track parks the monitor there — that alone is how a cut point gets found, so it happens even at the segment cap where no new block can be painted.

The clip track deliberately does **not** scrub the source: its x-axis is the recut's own timeline, which the source knows nothing about.

Seeks are frame-throttled with a timeout as the recovery path. rAF alone deadlocks the scrub in a hidden or occluded tab — the callback never runs, so a latch waiting on it never clears and the monitor stops following for the rest of the session.

### The whole transcript, not a window

`/edl` returned words within ±45s of the clip. But the point of the source track is extending a cut into material the clip never covered, and **you cannot pick a new in-point from words you were not sent**. It now returns the full source transcript — about 7 KB of JSON per minute of speech, fetched once per editor open.

The panel shows all of it, keeps the current segment's first word in view, lights the word being spoken as the monitor plays, and seeks the monitor when you click a word.

That last part forced a performance decision. Repainting ~2500 words costs **66ms**, and `timeupdate` fires four times a second, so the follow-along highlight would have stuttered the video outright. Words render in memoised 50-word slices that return Fragments — no wrapper elements, so the flex-wrap layout and the scroll anchor's `offsetTop` behave exactly as before. Untouched slices get stable primitive props and skip the render entirely; only the one or two straddling a segment edge repaint during a drag. Measured after: **zero long tasks over four seconds of playback**.

### Layout: two monitors, each with its own track

```
┌──────────────────────────┬─────────┬──────────┐
│ SOURCE   (16:9)          │ PROGRAM │ SEGMENTS │
│ ┌──────────────────────┐ │ ┌─────┐ │ FRAMING  │
│ └──────────────────────┘ │ │     │ │ toggles  │
│ ── SOURCE track ──────── │ │ 9:16│ │ ──────── │
│ 1·MARK in out │ 2·SEND   │ └─────┘ │ cancel   │
│ ── TRANSCRIPT ─────────  │ ─CLIP── │ RE-RENDER│
└──────────────────────────┴─────────┴──────────┘
```

Each track sits under the video it drives, which is why the bottom strip is gone. That strip cost ~140px of height, so the clip preview actually **grew** from 570 to 656px tall while the source monitor went from 336 to 639px wide and the transcript from 336×160 to 1012×206.

Column two is sized to the preview plus enough track to aim with rather than an equal share — extra width there is only black beside a height-bound video, and it is worth more to the source. Below `xl` everything stacks and scrolls.

There is an honest trade here: the tracks are narrower than the old full-width strip (source 1836 → ~1012px). Word snapping and the numeric fields in the Segments panel carry the fine precision; the tracks carry coarse positioning. I think that is the right split, but it is a real change and worth your eye.

**A "hide source" button** puts the whole source column away for anyone who just wants to trim a clip. It is not a new code path — an expired source already forces the same two-column layout, so the toggle just makes that state reachable by choice. The preference is kept in `localStorage`, source-only shortcuts go inert while it is away, and the clip track takes the full width (480 → 1508px), which hands back more trimming precision than the old strip had.

### The timeline works while the clip is edited

This is the part I would most like reviewed, because it changes an assumption the component was built on.

The editor treated "edited" as binary: any change set `dirty`, and from there the clip track stopped driving the video and the playhead stopped being drawn at all. But **a cut that only removes material keeps nothing but frames the last render already produced.** There was never a reason for it to go dark.

The rendered file is `renderedSegments` cut and concatenated in order (`perform_recut`), so any instant of source still inside one of those ranges exists in that file and can be played straight from it. A coverage model intersects the current segments with the rendered ones and returns spans of clip time, each carrying its offset into the rendered file, or `null` where the last render never saw that material.

From that:

- **Scrubbing** asks "does the file hold *this* instant", not "is the file stale". A trim is navigable again with no GPU work.
- **Playback** walks the assembly: it plays each covered span from the file, seeks to the next one at the seam, and stops at the edge of anything red rather than showing frames that are not in the edit. Starting from a red span refuses.
- **A render-status strip** runs along the top of the track, NLE style: red where material still needs rendering, dim green where it does not.
- **The playhead is a handle**, not a 1px line — the same solid, grabbable shape the source track uses. It cannot enter red; inside an unrendered span there is no frame to show, so a handle sitting there would point at nothing.
- A **framing change** paints everything red even where the ranges line up: the crop baked into those frames is not what will come out.

With nothing pending, all of this short-circuits to the previous behaviour — coverage is the identity mapping, there is no strip, and playback is 1:1 with no bookkeeping.

Two details that took a second pass:

*Seams are half-open* `[start, end)`. A position exactly on one belongs to the span that **starts** there, or the playhead reads as being on the next segment while the picture is still the tail of the previous one.

*The wall is path-aware.* Clamping only the destination let a fast drag tunnel clean through a red span, because the endpoint was green. A wall anywhere **between** the old and new position now blocks the move. A click may still cross — clicking is "go here", not continuous motion — which matches how sliders behave everywhere else.

The badge changed with it. `edited — re-render to see it here` is simply false for a pure trim, which now *is* visible. It reads either `previewing the edit · re-render to keep it` or how much still needs rendering. The point it preserves: previewing does not produce a file. The delivered MP4 still needs the re-render.

---

## What is deliberately not here

- **No live preview of unrendered material.** The Program monitor could play the raw source through the EDL for red spans, but it would show the 16:9 frame without the 9:16 crop or the captions — a different picture pretending to be the clip. Stopping at the wall says the true thing.
- **No changes to the render path.** `/rerender`, `perform_recut`, the fast/source path split and the metering are untouched. This PR only changes what the editor can show you before you commit GPU time.
- **No new endpoint.** The only backend change is `/edl` returning the full transcript instead of a window, plus the stale comment in its test.

---

## Testing

`tests/test_rerender_endpoint.py` and `tests/test_edit_builder.py` pass (35 tests). The full suite is 487 passed / 7 failed — those 7 fail identically on a clean `upstream/main` (`test_generation_controls`, `test_mcp_endpoint`, `test_subtitles`), so they are not from this branch.

The UI was verified against a synthetic fixture — a 120s `testsrc` source with the rendered file built as `[10,20] + [80,95]` concatenated, and a transcript of 240 words at predictable times — driving real pointer and keyboard events:

| Case | Result |
|---|---|
| Clip→source mapping across a segment boundary | clip 12.5s → source 82.5s, inside segment 2 |
| Pure trim `[10,20]`→`[12,18]` | no red; clip 3s → file 5s |
| Extension `[10,20]`→`[8,22]` | exactly two 2s red spans, at 6.90% and 41.38% of a 29s assembly |
| New `[50,60]` segment | red end to end; reported 0:14.0 needing render |
| Playback into red | stops dead at the wall; starting inside one refuses |
| Handle dragged through a wall | stops at the edge instead of tunnelling |
| Edit turning the handle's position red | handle pushed out to the nearest legal spot |
| Nothing pending | no strip, playback 1:1, handle slides the full length |
| Transcript follow-along | 77.5s lights `w155` (1:17.5); zero long tasks over 4s |
| Layout at 1908×892 and 1280×720 | no overflow, every control above the fold |

Plus the earlier regressions each time: trim handles trim rather than scrub, clicking a block selects and scrubs, the source track marks/moves/trims, `i`/`o`/`,`/`.`, word click seeks, hide-source at full width.

---

Happy to split this into smaller PRs if you would rather review it in pieces — the Chrome drag fix, the transcript change, the layout, and the coverage model are separable, though the layout and the transcript panel are entangled because the panel had to move for the follow-along to be worth anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
